### PR TITLE
Fixed "warning: Failure to find: include/osxtransparencysupport.h"

### DIFF
--- a/babelcalc.pro
+++ b/babelcalc.pro
@@ -12,7 +12,7 @@ HEADERS       = include/basicinput.h \
     include/modes.h \
     include/narrowlineedit.h \
     include/operators.h \
-    include/osxtransparencysupport.h \
+    include/OSXTransparencySupport.h \
     include/value.h
 
 SOURCES       = src/basicinput.cpp \


### PR DESCRIPTION
My guess is that it was added on a case-insensitive filesystem, as it was just a matter on non-matching case.