### PR TITLE
Added check to make sure there's an input in focus before trying to use it.

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -389,7 +389,14 @@ QString GUI::inputBaseToString(int base) {
 }
 
 void GUI::inputDigit(const QString &str) {
-	findFocusedInput()->inputDigits(str);
+	auto* const focusedInput = findFocusedInput();
+
+	if(focusedInput == nullptr) {
+		qWarning("No input in focus, cannot input digit");
+		return;
+	}
+
+	focusedInput->inputDigits(str);
 }
 
 void GUI::addNewInputBase(Input* input, bool canDisable, bool enabled)


### PR DESCRIPTION
Fixes a crash where user clicks "2s compliment" and then "F".

One could argue that there should be an input in focus, and that this is the real issue, but in any case we don't want a crash...